### PR TITLE
Cherry-pick DMA fix from zumer repo

### DIFF
--- a/src/crtcdmac.c
+++ b/src/crtcdmac.c
@@ -51,7 +51,8 @@ int		text_display = TEXT_ENABLE;	/* テキスト表示フラグ	*/
 int		blink_cycle;		/* 点滅の周期	8/16/24/32	*/
 int		blink_counter = 0;	/* 点滅制御カウンタ		*/
 
-int		dma_wait_count = 0;	/* DMAで消費するサイクル数	*/
+int     dma_wait_count = 0;     /* DMAウェイトの余った数    */
+int     dma_next_vline = 0;     /* DMAウェイトを再計算する次のステート数（vsync で初期化） */
 
 
 static	int	crtc_command;
@@ -766,6 +767,7 @@ static	T_SUSPEND_W	suspend_crtcdmac_work[]=
   { TYPE_INT,	&blink_counter,		},
 
   { TYPE_INT,	&dma_wait_count,	},
+  { TYPE_INT,   &dma_next_vline,    },
 
   { TYPE_INT,	&crtc_command,		},
   { TYPE_INT,	&crtc_param_num,	},

--- a/src/crtcdmac.h
+++ b/src/crtcdmac.h
@@ -50,10 +50,13 @@ void	set_text_display(void);
 
 
 
-extern	int	dma_wait_count;		/* DMAで消費するサイクル数	*/
+extern  int dma_wait_count;     /* DMAウェイトの余った数    */
+extern  int dma_next_vline;     /* DMAウェイトを再計算する次のステート数（vsync で初期化） */
+
+#define DMA_WAIT    (9)         /* DMAで消費するサイクル数    */
 
 #define	SET_DMA_WAIT_COUNT()	dma_wait_count =			\
-					crtc_byte_per_line * crtc_sz_lines
+                    crtc_byte_per_line / crtc_font_height /* 1走査線分のDMAウェイト数 */
 
 #define	RESET_DMA_WAIT_COUNT()	dma_wait_count = 0
 

--- a/src/intr.c
+++ b/src/intr.c
@@ -380,9 +380,7 @@ static	void	vsync( void )
 #endif
   }
 
-  SET_DMA_WAIT_COUNT();			/* DMA消費サイクル数セット */
-
-
+  dma_next_vline = 0;               /* 垂直帰線のステート数を初期化する */
   state_of_cpu -= state_of_vsync;	/* (== vsync_intr_base) */
 }
 

--- a/src/pc88main.c
+++ b/src/pc88main.c
@@ -604,13 +604,24 @@ byte	main_fetch( word addr )
 
   if( memory_wait ){
 
+      if (state_of_cpu + z80main_cpu.state0 >= dma_next_vline) {
+          /* vsync でDMAウェイトを一斉に計算するとBEEPの音出力に影響が出るため、
+             垂直帰線毎にDMAウェイトを初期化する */
+
+          SET_DMA_WAIT_COUNT();
+
+          /* 次の垂直帰線のステート数を計算する */
+
+          dma_next_vline += state_of_vsync / (crtc_sz_lines * crtc_font_height);
+      }
+
     if( high_mode == FALSE ){		/* 低速モードの場合 */
 
       z80main_cpu.state0 += 1;			/* M1サイクルウェイト */
 
-      if( dma_wait_count ){			/* DMAウェイトがあれば    */
-	dma_wait_count --;			/* すこしずつ加算していく */
-	z80main_cpu.state0 += DMA_WAIT;
+      if(dma_wait_count){         /* DMAウェイトがあれば    */
+        dma_wait_count--;          /* すこしずつ加算していく */
+        z80main_cpu.state0 += DMA_WAIT;
       }
 
     }else{				/* 高速モードの場合 */

--- a/src/pc88main.h
+++ b/src/pc88main.h
@@ -75,8 +75,6 @@ extern	byte	jisho_rom_ctrl;			/* OUT[F1] 辞書ROMバンク  */
 #define	MEMORY_BANK_GRAM1	(1)		/*		       R   */
 #define	MEMORY_BANK_GRAM2	(2)		/*		       G   */
 
-#define	CPU_CLOCK_4HMZ		(0x80)		/* CPU CLOCK 4MHz / 8MHz   */
-
 #define	EXT_ROM_NOT		(0x01)		/* 拡張 ROM 非セレクト	   */
 
 #define INTERRUPT_MASK_RTC	(0x01)		/* 1/600 割り込み 許可     */


### PR DESCRIPTION
Fix -mem_wait audio distortion

Occurred when running in mode V1S
due to front-loading DMA waits on
each vertical sync.