### PR TITLE
Undef INLINE after retro_endianness.h

### DIFF
--- a/src/LIBRETRO/config.h
+++ b/src/LIBRETRO/config.h
@@ -20,6 +20,9 @@
 
 #include <retro_endianness.h>
 
+/* Quasi88 uses inline differently from retro_inline. Undef it to
+   avoid conflicts.  */
+#undef INLINE
 
 
 /* メニューのタイトル／バージョン表示にて追加で表示する言葉 (任意の文字列) */


### PR DESCRIPTION
In retro headers INLINE=inline but in quasi88 INLINE=static. Undef it to avoid
compilation error