### PR TITLE
Set BASIC ROM version after the ROMs have been loaded

### DIFF
--- a/src/LIBRETRO/libretro.c
+++ b/src/LIBRETRO/libretro.c
@@ -556,7 +556,7 @@ void retro_init(void)
       memcpy(main_rom, &pbios_n88, 0x08000);
    if (!load_system_file(SUB_ROM, sub_romram, 0x00800))
       memcpy(sub_romram, &pbios_disk, 0x00800);
-
+   rom_version = ROM_VERSION;
    load_system_file(EXT0_ROM,  main_rom_ext[0], 0x02000);
    load_system_file(EXT1_ROM,  main_rom_ext[1], 0x02000);
    load_system_file(EXT2_ROM,  main_rom_ext[2], 0x02000);


### PR DESCRIPTION
In the standalone Quasi88, `rom_version` is initialized during `memory_allocate`([here](https://github.com/libretro/quasi88-libretro/blob/503315bec0779196ffc684ffd85e4c20e6b8366d/src/memory.c#L532)), but in the libretro core, the BASIC ROMs haven't been loaded at that time.
This change sets `rom_version` (based on the Basic ROM loaded), which is later used to set `ROM_VERSION`.

This fixes a game (maybe others?) that wasn't booting under the libretro core, but worked in standalone Quasi88 (ReFight (1991)).