### PR TITLE
Fix assigning of non-existent vfs_interface

### DIFF
--- a/src/LIBRETRO/libretro.c
+++ b/src/LIBRETRO/libretro.c
@@ -799,7 +799,6 @@ void retro_set_environment(retro_environment_t cb)
    vfs_interface_info.required_interface_version = FILESTREAM_REQUIRED_VFS_VERSION;
    vfs_interface_info.iface = NULL;
    if (cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_interface_info)) {
-     vfs_interface = vfs_interface_info.iface;
      filestream_vfs_init(&vfs_interface_info);
    }
 }


### PR DESCRIPTION
Fixes https://github.com/libretro/quasi88-libretro/issues/59