### PR TITLE
fix function key mapping

### DIFF
--- a/src/LIBRETRO/libretro.c
+++ b/src/LIBRETRO/libretro.c
@@ -293,7 +293,9 @@ static void handle_input(void)
 
    /* Function keys */
    for (i = 0; i < 5; i++)
-      handle_key(KEY88_F6 + i, RETROK_F1 + i);
+      handle_key(KEY88_F1 + i, RETROK_F1 + i);
+   for (i = 0; i < 5; i++)
+      handle_key(KEY88_F6 + i, RETROK_F6 + i);
 
    /* Joypads */
    mouse_mode = 3;


### PR DESCRIPTION
#71 fixed an issue where the F-key mapping were overwriting other keys, but the mapping itself was wrong.

Instead of mapping the real F1 key to the F6 key, it should map it to the F1 key. This PR does that, which fixes the ability to save/load in Ys. (F1=Load, F4=Save, F5=Format disk).