### PR TITLE
Fix several PCG-8100 emulation issues

### DIFF
--- a/src/LIBRETRO/libretro.c
+++ b/src/LIBRETRO/libretro.c
@@ -416,7 +416,7 @@ static void init_variables(void)
    else
       sound_board = SOUND_I;
   
-   var.key = "q88_use_pcg-8100";
+   var.key = "q88_pcg-8100";
    
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       use_pcg = (!strcmp(var.value, "enabled")) ? TRUE : FALSE;

--- a/src/pc88main.c
+++ b/src/pc88main.c
@@ -2745,7 +2745,7 @@ void	pc88main_init( int init )
 
 	/* フォント初期化 */
 
-  if( init == INIT_POWERON  ||  init == INIT_RESET ){
+  if( init == INIT_POWERON ){
 
     memory_reset_font();
   }else{

--- a/src/pc88main.c
+++ b/src/pc88main.c
@@ -171,6 +171,7 @@ static	void	pcg_out_addr_high( byte addr )
     else             { src = pcg_data; }			    /* store */
 
     font_pcg[ 0x400 + (pcg_addr&0x3ff) ] = src;
+    screen_set_dirty_all();
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes three independent issues affecting PCG-8100
emulation in the libretro port of QUASI88.

The PCG-8100 character generation code is already present in the
core, but several issues prevent it from behaving correctly in
software that uses programmable characters dynamically.

The fixes are:

1. Fix the PCG-8100 core option key mismatch.
2. Preserve PCG-8100 character RAM across a PC-8001 reset.
3. Redraw existing text characters when their PCG pattern is modified.

## 1. PCG-8100 core option key mismatch

The core option is defined as:

`q88_pcg-8100`

but `libretro.c` queries:

`q88_use_pcg-8100`

Because these keys do not match, enabling "Use PCG-8100" in the
RetroArch core options does not correctly set `use_pcg`.

This change makes the queried key match the registered core option.

## 2. PCG character RAM is incorrectly cleared on reset

The existing initialization code calls `memory_reset_font()` for
both `INIT_POWERON` and `INIT_RESET`.

`memory_reset_font()` copies the built-in font ROM into
`font_pcg`, destroying all programmed PCG character patterns.

This does not match the behavior of the original hardware.

I previously owned and used an original NEC PC-8001 together with
a PCG-8100. The PCG-8100 has its own character RAM and a physical
switch that selects whether characters are displayed using the
original PC-8001 character ROM or the PCG-8100 character RAM.

Resetting the PC-8001 does not clear the PCG-8100 character RAM.
Programmed PCG patterns remain intact across a normal PC-8001
reset.

This PR therefore initializes `font_pcg` only on `INIT_POWERON`
and preserves it across `INIT_RESET`.

## 3. Existing characters are not redrawn after a PCG pattern update

PCG-8100 software can change the bitmap of a character that is
already present on the text screen without changing text VRAM.

The libretro version currently updates `font_pcg`, but does not
mark the displayed text as dirty.

As a result, software that updates only the PCG pattern does not
show the new glyph until some unrelated redraw occurs.

The current desktop QUASI88 implementation already performs
equivalent screen invalidation after modifying a PCG character
pattern.

This PR adds `screen_set_dirty_all()` after updating `font_pcg`.

## Real-world examples

New City Hero uses real-time PCG pattern modification for animation:

https://codeknowledge.livedoor.blog/archives/15458058.html

PCG8100_graphic_routines implements graphics-like pixel plotting
by modifying PCG patterns while retaining the same character in
text VRAM:

https://github.com/kazenif/PCG8100_graphic_routines

## Testing

Tested with an AArch64 build of `quasi88-libretro` on:

- TrimUI Smart Pro S
- spruceOS 4.3.x
- RetroArch

The core was cross-compiled in a Docker-based Ubuntu 18.04
environment using GCC 7.5.0 for AArch64 and remains compatible
with GLIBC 2.27.

Confirmed:

- the PCG-8100 core option correctly enables PCG character display;
- programmed PCG character patterns survive a PC-8001 reset;
- newly written text characters continue to use programmed PCG glyphs;
- modifying a PCG pattern for a character already present on screen
  is immediately reflected after the redraw fix.

For the redraw fix, I tested a circle-drawing demo that plots pixels
by modifying PCG character patterns while keeping the same text VRAM
characters in place.

Before the fix, only the initial text VRAM write triggered redraw,
so the final image was broken and incomplete.

After the fix, the same demo correctly renders clean concentric
circles.

## Hardware behavior note

On original PCG-8100 hardware, character RAM powers up with
undefined contents rather than a copy of the PC-8001 font ROM.

This PR intentionally does not change the existing power-on
initialization behavior. It only fixes preservation of PCG RAM
across a normal PC-8001 reset.

### PCG redraw test

Before the redraw fix:
<img width="1152" height="720" alt="00_OLD_PCGDEMO-before-fix" src="https://github.com/user-attachments/assets/349c6e0f-e651-45c8-b721-319365bfa509" />

After the redraw fix:
<img width="1152" height="720" alt="00_OLD_PCGDEMO-after-fix" src="https://github.com/user-attachments/assets/22f75440-8554-4b97-9894-53e74156c68e" />
